### PR TITLE
TK-252 Always build a metrics registry, deprecate metrics.enabled

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -9,9 +9,6 @@ Here is a sample config file that illustrates the available settings for metrics
 
 ```
 metrics: {
-    # enable or disable the metrics system
-    enabled: true
-
     # a server id that will be used as part of the namespace for metrics produced
     # by this server
     server-id: localhost

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-core
   (:import (com.codahale.metrics JmxReporter MetricRegistry))
-  (:require [schema.core :as schema]
+  (:require [clojure.tools.logging :as log]
+            [schema.core :as schema]
             [puppetlabs.kitchensink.core :as ks]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -35,15 +36,15 @@
 
 (schema/defn initialize :- MetricsServiceContext
   [config :- MetricsConfig]
-  (let [enabled         (ks/to-bool (:enabled config))
+  (let [enabled-given   (contains? config :enabled)
         jmx-config      (get-in config [:reporters :jmx])]
-    (if-not enabled
-      {:registry nil}
-      (let [registry (MetricRegistry.)]
-        (cond-> {:registry registry}
+    (when enabled-given
+      (log/warn "Metrics are now always enabled.  To suppress this warning remove metrics.enabled from your configuration."))
+    (let [registry (MetricRegistry.)]
+      (cond-> {:registry registry}
 
-          (:enabled jmx-config)
-          (assoc :jmx-reporter (jmx-reporter registry jmx-config)))))))
+        (:enabled jmx-config)
+        (assoc :jmx-reporter (jmx-reporter registry jmx-config))))))
 
 (schema/defn stop :- MetricsServiceContext
   [context :- MetricsServiceContext]

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -1,22 +1,24 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-core-test
   (:import (com.codahale.metrics MetricRegistry JmxReporter))
   (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.testutils.logging :refer :all]
             [puppetlabs.trapperkeeper.services.metrics.metrics-core :refer :all]
             [schema.test :as schema-test]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
 (deftest test-initialize
-  (testing "does not initialize registry if metrics are disabled"
-    (let [context (initialize {:enabled false :server-id "localhost"})]
-      (is (nil? (:registry context)))))
-  (testing "initializes registry and adds to context if metrics are enabled"
-    (let [context (initialize {:enabled true :server-id "localhost"})]
+  (testing "it logs if :enabled is provided"
+    (with-test-logging
+      (let [context (initialize {:server-id "localhost" :enabled false})]
+        (is (logged? #"^Metrics are now always enabled." :warn))
+        (is (instance? MetricRegistry (:registry context))))))
+  (testing "initializes registry and adds to context"
+    (let [context (initialize {:server-id "localhost"})]
       (is (instance? MetricRegistry (:registry context)))
       (is (not (contains? context :jmx-reporter)))))
   (testing "enables jmx reporter if configured to do so"
-    (let [context (initialize {:enabled true
-                               :server-id "localhost"
+    (let [context (initialize {:server-id "localhost"
                                :reporters
                                {:jmx {:enabled true}}})]
       (is (instance? MetricRegistry (:registry context)))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -11,7 +11,6 @@
 
 (deftest test-metrics-service
   (testing "Can boot metrics service and access registry"
-    (with-app-with-config app [metrics-service] {:metrics {:enabled true
-                                                           :server-id "localhost"}}
+    (with-app-with-config app [metrics-service] {:metrics {:server-id "localhost"}}
       (let [svc (app/get-service app :MetricsService)]
         (is (instance? MetricRegistry (metrics-protocol/get-metrics-registry svc)))))))


### PR DESCRIPTION
Previously we have allowed the user to disable the creation of a
MetricsRegistry with the `metrics.enabled` option, though this means
the developer had to guard against a nil registry in all codepaths.

Metrics collection is very light and so here we make the change to
always create a MetricsRegisty, and log a warning message if
`metrics.enabled` is provided.