### PR TITLE
TK-253 become a wrapper for metrics-clojure's default-registry

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
 
                  [org.clojure/tools.logging "0.2.6"]
                  [org.slf4j/slf4j-api "1.7.7"]
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]]
+                 [metrics-clojure "2.5.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-core
   (:import (com.codahale.metrics JmxReporter MetricRegistry))
   (:require [schema.core :as schema]
+            [metrics.core]
             [puppetlabs.kitchensink.core :as ks]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -39,7 +40,7 @@
         jmx-config      (get-in config [:reporters :jmx])]
     (if-not enabled
       {:registry nil}
-      (let [registry (MetricRegistry.)]
+      (let [registry metrics.core/default-registry]
         (cond-> {:registry registry}
 
           (:enabled jmx-config)

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-core-test
   (:import (com.codahale.metrics MetricRegistry JmxReporter))
   (:require [clojure.test :refer :all]
+            [metrics.core]
             [puppetlabs.trapperkeeper.services.metrics.metrics-core :refer :all]
             [schema.test :as schema-test]))
 
@@ -10,9 +11,10 @@
   (testing "does not initialize registry if metrics are disabled"
     (let [context (initialize {:enabled false :server-id "localhost"})]
       (is (nil? (:registry context)))))
-  (testing "initializes registry and adds to context if metrics are enabled"
+  (testing "adds the metrics.core/default-registry to context"
     (let [context (initialize {:enabled true :server-id "localhost"})]
       (is (instance? MetricRegistry (:registry context)))
+      (is (= metrics.core/default-registry (:registry context)))
       (is (not (contains? context :jmx-reporter)))))
   (testing "enables jmx reporter if configured to do so"
     (let [context (initialize {:enabled true


### PR DESCRIPTION
Here we depend on the metrics-clojure wrapper for Dropwizard Metrics and use
the global MetricsRegistry that it creates rather than construct our own.

This allows a hybrid usage pattern where metrics may be declared globally and
used without threading the tk-metrics MetricsRegistry though the application,
but we are still able to configure JMX Publishing via service configuration files.