### PR TITLE
(PDB-1531) Add mbeans handler and ability to configure multiple registries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(def ks-version "1.1.0")
-(def tk-version "1.1.1")
+(def ks-version "1.2.0")
+(def tk-version "1.2.0")
 
 (defproject puppetlabs/trapperkeeper-metrics "0.1.3-SNAPSHOT"
   :description "Trapperkeeper Metrics Service"
@@ -7,22 +7,41 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time "0.7.0"]
-                 [commons-io "2.4"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
 
-                 [puppetlabs/kitchensink "1.1.0"]
+                 ;; begin version conflict resolution dependencies
+                 [clj-time "0.10.0"]
+                 [commons-codec "1.9"]
+                 [org.clojure/tools.macro "0.1.5"]
+                 [commons-io "2.4"]
+                 ;; end version conflict resolution dependencies
+
+                 [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
+
+                 [ring/ring-core "1.4.0"]
+
+                 [cheshire "5.3.1"]
+                 [org.clojure/java.jmx "0.3.1"]
+                 ;; ring-defaults brings in a bad, old version of the servlet-api, which
+                 ;; now has a new artifact name (javax.servlet/javax.servlet-api).  If we
+                 ;; don't exclude the old one here, they'll both be brought in, and consumers
+                 ;; will be subject to the whims of which one shows up on the classpath first.
+                 ;; thus, we need to use exclusions here, even though we'd normally resolve
+                 ;; this type of thing by just specifying a fixed dependency version.
+                 [ring/ring-defaults "0.1.5" :exclusions [javax.servlet/servlet-api]]
 
                  [org.clojure/tools.logging "0.2.6"]
                  [org.slf4j/slf4j-api "1.7.7"]
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]]
+                 [io.dropwizard.metrics/metrics-core "3.1.2"]
+                 [puppetlabs/comidi "0.3.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-
-  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test"]
+  :profiles {:dev {:dependencies [[puppetlabs/http-client "0.4.4" :exclusions [commons-io]]
+                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1" :exclusions [clj-time]]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]]}})

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -2,6 +2,12 @@
   (:import (com.codahale.metrics JmxReporter MetricRegistry))
   (:require [clojure.tools.logging :as log]
             [schema.core :as schema]
+            [ring.middleware.defaults :as ring-defaults]
+            [puppetlabs.comidi :as comidi]
+            [puppetlabs.trapperkeeper.services.metrics.ringutils
+             :as ringutils]
+            [puppetlabs.trapperkeeper.services.metrics.metrics-utils
+             :as metrics-utils]
             [puppetlabs.kitchensink.core :as ks]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -18,36 +24,77 @@
    (schema/optional-key :enabled)   schema/Bool
    (schema/optional-key :reporters) ReportersConfig})
 
-(def MetricsServiceContext
+(def RegistryContext
   {:registry (schema/maybe MetricRegistry)
-   (schema/optional-key :jmx-reporter) JmxReporter})
+   :jmx-reporter (schema/maybe JmxReporter)})
+
+(def MetricsServiceContext
+  {:registries (schema/atom {schema/Any RegistryContext})})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
-(defn jmx-reporter
-  [registry jmx-config]
-  (doto (-> (JmxReporter/forRegistry registry)
-          (.build))
-    (.start)))
+(schema/defn jmx-reporter :- JmxReporter
+  [registry :- MetricRegistry
+   domain :- (schema/maybe schema/Str)]
+  (let [b (JmxReporter/forRegistry registry)]
+    (when-let [^String d domain]
+      (.inDomain b d))
+    (.build b)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
-(schema/defn initialize :- MetricsServiceContext
-  [config :- MetricsConfig]
-  (let [enabled-given   (contains? config :enabled)
-        jmx-config      (get-in config [:reporters :jmx])]
-    (when enabled-given
-      (log/warn "Metrics are now always enabled.  To suppress this warning remove metrics.enabled from your configuration."))
-    (let [registry (MetricRegistry.)]
-      (cond-> {:registry registry}
+(schema/defn initialize :- RegistryContext
+  [config :- MetricsConfig
+   domain :- (schema/maybe schema/Str)]
+  (let [jmx-config (get-in config [:reporters :jmx])
+        registry (MetricRegistry.)]
+    (when (contains? config :enabled)
+      (log/warn (str "Metrics are now always enabled.  "
+                     "To suppress this warning remove "
+                     "metrics.enabled from your configuration.")))
+    {:registry registry
+     :jmx-reporter (when (:enabled jmx-config)
+                     (doto ^JmxReporter (jmx-reporter registry domain)
+                       (.start)))}))
 
-        (:enabled jmx-config)
-        (assoc :jmx-reporter (jmx-reporter registry jmx-config))))))
+(schema/defn get-or-initialize! :- RegistryContext
+  [config :- MetricsConfig
+   {:keys [registries] :as context} :- MetricsServiceContext
+   registry-key :- schema/Keyword
+   domain :- schema/Str]
+  (if-let [metric-reg (get-in @registries [registry-key])]
+    metric-reg
+    (let [reg-context (initialize config domain)]
+      (swap! registries assoc registry-key reg-context)
+      reg-context)))
 
-(schema/defn stop :- MetricsServiceContext
-  [context :- MetricsServiceContext]
+(schema/defn stop :- RegistryContext
+  [context :- RegistryContext]
   (if-let [jmx-reporter (:jmx-reporter context)]
     (.close jmx-reporter))
   context)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Comidi
+
+(defn build-handler [path]
+  (comidi/routes->handler
+   (comidi/wrap-routes
+    (comidi/context path
+        (comidi/context "/v1"
+            (comidi/context "/mbeans"
+              (comidi/GET "" []
+                (fn [req]
+                  (ringutils/json-response 200
+                                           (metrics-utils/mbean-names))))
+            (comidi/GET ["/" [#".*" :names]] []
+              (fn [{:keys [route-params] :as req}]
+                (let [name (java.net.URLDecoder/decode (:names route-params))]
+                  (if-let [mbean (metrics-utils/get-mbean name)]
+                    (ringutils/json-response 200 mbean)
+                    (ringutils/json-response 404
+                                              (format "No mbean '%s' found" name)))))))))
+    #(ring-defaults/wrap-defaults % ring-defaults/api-defaults))))

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -61,7 +61,7 @@
 
 (schema/defn get-or-initialize! :- RegistryContext
   [config :- MetricsConfig
-   {:keys [registries] :as context} :- MetricsServiceContext
+   {:keys [registries]} :- MetricsServiceContext
    registry-key :- schema/Keyword
    domain :- schema/Str]
   (if-let [metric-reg (get-in @registries [registry-key])]
@@ -90,11 +90,11 @@
                 (fn [req]
                   (ringutils/json-response 200
                                            (metrics-utils/mbean-names))))
-            (comidi/GET ["/" [#".*" :names]] []
-              (fn [{:keys [route-params] :as req}]
-                (let [name (java.net.URLDecoder/decode (:names route-params))]
-                  (if-let [mbean (metrics-utils/get-mbean name)]
-                    (ringutils/json-response 200 mbean)
-                    (ringutils/json-response 404
-                                              (format "No mbean '%s' found" name)))))))))
+              (comidi/GET ["/" [#".*" :names]] []
+                (fn [{:keys [route-params] :as req}]
+                  (let [name (java.net.URLDecoder/decode (:names route-params))]
+                    (if-let [mbean (metrics-utils/get-mbean name)]
+                      (ringutils/json-response 200 mbean)
+                      (ringutils/json-response 404
+                                                (format "No mbean '%s' found" name)))))))))
     #(ring-defaults/wrap-defaults % ring-defaults/api-defaults))))

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -6,13 +6,9 @@
 
 (trapperkeeper/defservice metrics-service
   metrics/MetricsService
-  [[:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler get-route]]
+  [[:ConfigService get-in-config]]
 
   (init [this context]
-    (when (get-in-config [:metrics :reporters :jmx :enabled] false)
-      (add-ring-handler this
-                        (core/build-handler (get-route this))))
     {:registries
      (atom {::default-registry
             (core/initialize (get-in-config [:metrics] {})
@@ -35,4 +31,16 @@
           (tk-services/service-context this)
           registry-key
           domain))))
+
+(trapperkeeper/defservice metrics-webservice
+  [[:ConfigService get-in-config]
+   [:WebroutingService add-ring-handler get-route]]
+
+  (init [this context]
+        (when (get-in-config [:metrics :reporters :jmx :enabled] false)
+          (add-ring-handler this
+                            (core/build-handler (get-route this))))
+        context)
+
+  (stop [this context] context))
 

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_utils.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_utils.clj
@@ -1,0 +1,42 @@
+(ns puppetlabs.trapperkeeper.services.metrics.metrics-utils
+  (:require [cheshire.custom :refer [JSONable]]
+            [clojure.java.jmx :as jmx]
+            [puppetlabs.kitchensink.core :as ks]))
+
+(defn filter-mbean
+  "Converts an mbean to a map. For attributes that can't be converted to JSON,
+  return a string representation of the value."
+  [mbean]
+  {:post [(map? %)]}
+  (->> mbean
+       (ks/mapvals (fn [v]
+                     (cond
+                       ;; Nested structures should themselves be filtered
+                       (map? v) (filter-mbean v)
+                       (instance? java.util.HashMap v) (->> v
+                                                            (into {})
+                                                            filter-mbean)
+                       (satisfies? JSONable v) v
+                       :else (str v))))))
+
+(defn all-mbean-names
+  "Return a seq of all mbeans names"
+  []
+  {:post [(coll? %)]}
+  (map str (jmx/mbean-names "*:*")))
+
+(defn mbean-names
+  "Return a map of mbean name to a link that will retrieve the attributes"
+  []
+  (->> (all-mbean-names)
+       (map (fn [mbean-name]
+              [mbean-name
+               (format "/mbeans/%s" (java.net.URLEncoder/encode mbean-name "UTF-8"))]))
+       (into (sorted-map))))
+
+(defn get-mbean
+  "Returns the attributes of a given MBean"
+  [name]
+  (when (some #(= name %) (all-mbean-names))
+    (filter-mbean
+     (jmx/mbean name))))

--- a/src/puppetlabs/trapperkeeper/services/metrics/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/ringutils.clj
@@ -1,0 +1,10 @@
+(ns puppetlabs.trapperkeeper.services.metrics.ringutils
+  (:require [cheshire.core :as json]
+            [ring.util.response :as response]))
+
+(defn json-response [status body]
+  (-> body
+      (json/generate-string {:pretty true})
+      response/response
+      (response/status status)
+      (response/content-type "application/json; charset=utf-8")))

--- a/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
@@ -2,5 +2,11 @@
 
 (defprotocol MetricsService
   "A service that tracks runtime metrics for the process."
-  (get-metrics-registry [this] "Provides access to the MetricsRegistry instance
-                                where metrics are stored."))
+  (get-metrics-registry
+    [this]
+    [this registry-key domain]
+    "Provides access to a MetricsRegistry configured with ops where `registry`
+     is the keyword used to look up the registry. Specifing no `registry` will
+     return the default MetricsRegistry. The `domain` is the name that will
+     appear at the front of the JMX metric. For example in `foo:name=my-metric`,
+     `foo` is the `domain`."))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -10,16 +10,16 @@
 (deftest test-initialize
   (testing "it logs if :enabled is provided"
     (with-test-logging
-      (let [context (initialize {:server-id "localhost" :enabled false})]
+      (let [context (initialize {:server-id "localhost" :enabled false} nil)]
         (is (logged? #"^Metrics are now always enabled." :warn))
         (is (instance? MetricRegistry (:registry context))))))
   (testing "initializes registry and adds to context"
-    (let [context (initialize {:server-id "localhost"})]
+    (let [context (initialize {:server-id "localhost"} "my.epic.domain")]
       (is (instance? MetricRegistry (:registry context)))
-      (is (not (contains? context :jmx-reporter)))))
+      (is (nil? (:jmx-reporter context)))))
   (testing "enables jmx reporter if configured to do so"
     (let [context (initialize {:server-id "localhost"
                                :reporters
-                               {:jmx {:enabled true}}})]
+                               {:jmx {:enabled true}}} "foo.bar.baz")]
       (is (instance? MetricRegistry (:registry context)))
       (is (instance? JmxReporter (:jmx-reporter context) )))))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -1,16 +1,62 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-service-test
   (:import (com.codahale.metrics MetricRegistry))
   (:require [clojure.test :refer :all]
+            [cheshire.core :as json]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.metrics :as metrics]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :refer :all]
             [puppetlabs.trapperkeeper.services.protocols.metrics :as metrics-protocol]
             [schema.test :as schema-test]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9-service]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.app :as app]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
+(defn parse-response
+  ([resp]
+   (parse-response resp false))
+  ([resp keywordize?]
+   (json/parse-string (slurp (:body resp)) keywordize?)))
+
+(def metrics-service-config
+  {:metrics {:server-id "localhost"
+             :reporters {:jmx {:enabled true}}}
+   :webserver {:port 8180
+               :host "0.0.0.0"}
+   :web-router-service {:puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service "/metrics"}})
+
 (deftest test-metrics-service
   (testing "Can boot metrics service and access registry"
-    (with-app-with-config app [metrics-service] {:metrics {:server-id "localhost"}}
+    (with-app-with-config app [jetty9-service/jetty9-service
+                               webrouting-service/webrouting-service
+                               metrics-service] metrics-service-config
       (let [svc (app/get-service app :MetricsService)]
-        (is (instance? MetricRegistry (metrics-protocol/get-metrics-registry svc)))))))
+        (is (instance? MetricRegistry (metrics-protocol/get-metrics-registry svc))))
+
+      (let [svc (app/get-service app :MetricsService)]
+        (is (instance? MetricRegistry
+                       (metrics-protocol/get-metrics-registry svc ::my-reg "pl.foo.reg"))))
+
+      (testing "returns latest status for all services"
+        (let [resp (http-client/get "http://localhost:8180/metrics/v1/mbeans")
+              body (parse-response resp)]
+          (is (= 200 (:status resp)))
+          (doseq [[metric path] body
+                  :let [resp (http-client/get (str "http://localhost:8180/metrics/v1" path))]]
+            (is (= 200 (:status resp))))))
+
+      (testing "register should add a metric to the registry"
+        (let [svc (app/get-service app :MetricsService)
+              registry (metrics-protocol/get-metrics-registry svc ::my-reg "pl.foo.reg")]
+          (metrics/register registry
+                            (metrics/host-metric-name "localhost" "foo")
+                            (metrics/gauge 2))
+          (let [resp (http-client/get
+                      (java.net.URLDecoder/decode
+                       (str "http://localhost:8180/metrics/v1/mbeans/"
+                            "pl.foo.reg:name=puppetlabs.localhost.foo")))
+                body (parse-response resp)]
+            (is (= 200 (:status resp)))
+            (is (= {"Value" 2} body))))))))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -25,13 +25,15 @@
              :reporters {:jmx {:enabled true}}}
    :webserver {:port 8180
                :host "0.0.0.0"}
-   :web-router-service {:puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service "/metrics"}})
+   :web-router-service {:puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
+                        "/metrics"}})
 
 (deftest test-metrics-service
   (testing "Can boot metrics service and access registry"
     (with-app-with-config app [jetty9-service/jetty9-service
                                webrouting-service/webrouting-service
-                               metrics-service] metrics-service-config
+                               metrics-service
+                               metrics-webservice] metrics-service-config
       (let [svc (app/get-service app :MetricsService)]
         (is (instance? MetricRegistry (metrics-protocol/get-metrics-registry svc))))
 


### PR DESCRIPTION
This PR adds the ability to use multiple registries with tk-metrics by adding a protocol function that "upserts" registries on calls to `(get-metrics-registry <name of registry> <opts>)`