### PR TITLE
(maint) Use `domain` string for registry lookup

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -58,7 +58,7 @@ namespace of the reporter for that registry.
   [[:MetricsService get-metrics-registry]]
   (init [this context]
     (let [default-metrics-registry (get-metrics-registry)
-          my-metrics-registry (get-metrics-registry ::my-registry "my.metrics.domain")
+          my-metrics-registry (get-metrics-registry "my.metrics.domain")
           ;; This will create the metric
           ;; `my.metrics.domain:name=puppetlabs.localhost.my-metric`
           my-metric-name (metrics/host-metric-name "localhost" "my-metric")
@@ -69,7 +69,7 @@ namespace of the reporter for that registry.
 
   (start [this context]
     ;; We can retrieve the same metrics-registry later.
-    (let [my-metrics-registry (get-metrics-registry ::my-registry "my.metrics.domain")]
+    (let [my-metrics-registry (get-metrics-registry "my.metrics.domain")]
       (do-some-other-work my-metrics-registry))
     context))
 ```

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -62,12 +62,11 @@
 (schema/defn get-or-initialize! :- RegistryContext
   [config :- MetricsConfig
    {:keys [registries]} :- MetricsServiceContext
-   registry-key :- schema/Keyword
    domain :- schema/Str]
-  (if-let [metric-reg (get-in @registries [registry-key])]
+  (if-let [metric-reg (get-in @registries [domain])]
     metric-reg
     (let [reg-context (initialize config domain)]
-      (swap! registries assoc registry-key reg-context)
+      (swap! registries assoc domain reg-context)
       reg-context)))
 
 (schema/defn stop :- RegistryContext

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -10,7 +10,7 @@
 
   (init [this context]
     {:registries
-     (atom {::default-registry
+     (atom {"default"
             (core/initialize (get-in-config [:metrics] {})
                              nil)})})
 
@@ -22,14 +22,13 @@
 
   (get-metrics-registry [this]
     (-> @(:registries (tk-services/service-context this))
-        ::default-registry
+        (get "default")
         :registry))
 
-  (get-metrics-registry [this registry-key domain]
+  (get-metrics-registry [this domain]
     (:registry
       (core/get-or-initialize! (get-in-config [:metrics] {})
           (tk-services/service-context this)
-          registry-key
           domain))))
 
 (trapperkeeper/defservice metrics-webservice

--- a/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
@@ -4,9 +4,9 @@
   "A service that tracks runtime metrics for the process."
   (get-metrics-registry
     [this]
-    [this registry-key domain]
-    "Provides access to a MetricsRegistry configured with ops where `registry`
-     is the keyword used to look up the registry. Specifing no `registry` will
-     return the default MetricsRegistry. The `domain` is the name that will
-     appear at the front of the JMX metric. For example in `foo:name=my-metric`,
-     `foo` is the `domain`."))
+    [this domain]
+    "Provides access to a MetricsRegistry where `domain` is the string used to
+     look up the registry. Specifing no `domain` will return the default
+     MetricsRegistry. The `domain` is the name that will appear at the front of
+     the JMX metric. For example in `foo:name=my-metric`, `foo` is the
+     `domain`."))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -39,7 +39,7 @@
 
       (let [svc (app/get-service app :MetricsService)]
         (is (instance? MetricRegistry
-                       (metrics-protocol/get-metrics-registry svc ::my-reg "pl.foo.reg"))))
+                       (metrics-protocol/get-metrics-registry svc "pl.foo.reg"))))
 
       (testing "returns latest status for all services"
         (let [resp (http-client/get "http://localhost:8180/metrics/v1/mbeans")
@@ -51,7 +51,7 @@
 
       (testing "register should add a metric to the registry"
         (let [svc (app/get-service app :MetricsService)
-              registry (metrics-protocol/get-metrics-registry svc ::my-reg "pl.foo.reg")]
+              registry (metrics-protocol/get-metrics-registry svc "pl.foo.reg")]
           (metrics/register registry
                             (metrics/host-metric-name "localhost" "foo")
                             (metrics/gauge 2))


### PR DESCRIPTION
Prior to this commit when configuring multiple registries, a user could
create 2 different registries using the same domain, which cause one
jmx-reporter to shaadow the other, this commit uses the domain as the
lookup for the metrics-service atom which enforces `domain` uniqueness.