### PR TITLE
(maint) Fix broken get-metrics-registry call after domain change

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -66,9 +66,7 @@
 
       (testing "querying multiple metrics via POST should work"
         (let [svc (app/get-service app :MetricsService)
-              registry (metrics-protocol/get-metrics-registry svc
-                                                              ::my-other-reg
-                                                              "pl.other.reg")]
+              registry (metrics-protocol/get-metrics-registry svc "pl.other.reg")]
           (metrics/register registry
                             (metrics/host-metric-name "localhost" "foo")
                             (metrics/gauge 2))


### PR DESCRIPTION
This commit fixes the broken get-metrics-registry call after the domain
passing change where we now use the domain for metrics-registry lookup.