### PR TITLE
[DNM] (SERVER-1310) Use standardized errors

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -7,7 +7,7 @@
             [schema.core :as schema]
             [ring.middleware.defaults :as ring-defaults]
             [puppetlabs.comidi :as comidi]
-            [puppetlabs.ring-middleware.core :as ringutils]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.trapperkeeper.services.metrics.metrics-utils
              :as metrics-utils]
             [puppetlabs.kitchensink.core :as ks]))


### PR DESCRIPTION
This moves us to the standard error format described in the [nogui](https://github.com/puppetlabs/puppet-nogui/blob/master/patterns/api_style_guide.md#errors) repo.

This is currently Do Not Merge [DNM] prep for after we have released ring-middleware 0.4.0.
We will also need to:
 - [ ] Update this to pull in the newest ring-middleware
 - [ ] Potentially update this for the reorg of helpers in ring-middleware into a utils namespace (not sure if that will land in 0.4.0).