### PR TITLE
(PE-16072) (PE-15848) Add i18n libraries to trapperkeeper-metrics 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,10 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-api "1.7.13"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
-                 [puppetlabs/comidi "0.3.1"]]
+                 [puppetlabs/comidi "0.3.1"]
+                 [puppetlabs/i18n "0.4.1"]]
+
+  :plugins [[puppetlabs/i18n "0.4.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  [puppetlabs/comidi "0.3.1"]
                  [puppetlabs/i18n "0.4.1"]]
 
-  :plugins [[puppetlabs/i18n "0.4.0"]]
+  :plugins [[puppetlabs/i18n "0.4.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
This commit is for the i18n of puppet server repositories. 
- externalize strings
- add i18n libraries
- set up middleware to allow for i18n to work on strings in HTTP requests
- add Makefile with fixed typo

Note that the Makefile will be overwritten each time `lein i18n init` is called. The Makefile committed in this PR is for the sake of letting users know that this typo needs to be fixed manually until [this PR](https://github.com/puppetlabs/clj-i18n/pull/22) gets merged into the clj-i18n library.