### PR TITLE
(MAINT) Explicity add servlet api dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,9 @@
                  ;; thus, we need to use exclusions here, even though we'd normally resolve
                  ;; this type of thing by just specifying a fixed dependency version.
                  [ring/ring-defaults "0.1.5" :exclusions [javax.servlet/servlet-api]]
+                 ;; Explicitly reference the correct servlet-api so that downstream
+                 ;; projects will always get it
+                 [javax.servlet/javax.servlet-api "3.1.0"]
 
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-api "1.7.13"]


### PR DESCRIPTION
TK metrics happens by luck to pull in the correct servlet-api dependency
through ring-servlet. This commit just makes it explicit so that downstream
consumers aren't at risk of missing it/having to specify the dependency
themselves