### PR TITLE
(maint) Fix ringutils alias

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -7,7 +7,7 @@
             [schema.core :as schema]
             [ring.middleware.defaults :as ring-defaults]
             [puppetlabs.comidi :as comidi]
-            [puppetlabs.ring-middleware.core :as ringutils]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.trapperkeeper.services.metrics.metrics-utils
              :as metrics-utils]
             [puppetlabs.kitchensink.core :as ks]


### PR DESCRIPTION
`ringutils` needs to be aliased to puppetlabs.ring-middleware.utils, not
.core, since utils has `json-response`.