### PR TITLE
(PE-14959) Add initialize-registry-settings to protocol

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -29,7 +29,10 @@
     (:registry
       (core/get-or-initialize! (get-in-config [:metrics] {})
           (tk-services/service-context this)
-          domain))))
+          domain)))
+
+  (initialize-registry-settings [this domain settings]
+    nil))
 
 (trapperkeeper/defservice metrics-webservice
   [[:ConfigService get-in-config]

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -32,7 +32,8 @@
           domain)))
 
   (initialize-registry-settings [this domain settings]
-    nil))
+   (throw (RuntimeException.
+           "`initialize-registry-settings` is not yet implemented for this service"))))
 
 (trapperkeeper/defservice metrics-webservice
   [[:ConfigService get-in-config]

--- a/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/metrics.clj
@@ -9,4 +9,11 @@
      look up the registry. Specifing no `domain` will return the default
      MetricsRegistry. The `domain` is the name that will appear at the front of
      the JMX metric. For example in `foo:name=my-metric`, `foo` is the
-     `domain`."))
+     `domain`.")
+
+  (initialize-registry-settings
+   [this domain settings]
+   "Allows for specifying settings for a metric registry reporter that don't
+   go into a config file. Must be called during the 'init' phase of a
+   service's lifecycle. Will error if called more than once per metric
+   registry."))


### PR DESCRIPTION
Add an `initialize-registry-settings` function to the MetricsService protocol.
In trapperkeeper-metrics the implementation of this function does not do
anything.