### PR TITLE
(PE-17031) Don't require jmx to be enabled for the metrics endpoint

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -40,10 +40,9 @@
    [:WebroutingService add-ring-handler get-route]]
 
   (init [this context]
-        (when (get-in-config [:metrics :reporters :jmx :enabled] false)
-          (add-ring-handler this
-                            (core/build-handler (get-route this))))
-        context)
+    (add-ring-handler this
+                      (core/build-handler (get-route this)))
+    context)
 
   (stop [this context] context))
 


### PR DESCRIPTION
Previously, the `/metrics` endpoint was only enabled if the `jmx` reporter was
enabled in the `reporters` section of the config. However, even if jmx isn't enabled for our registries, other mbeans will be
available - e.g. memory usage mbeans and jetty mbeans.

This commit makes it so that even if jmx is not enabled, if the
`metrics-webservice` has been added to the config then the `/metrics` endpoint
will be present.