### PR TITLE
(TK-404) Add jolokia Servlet as metrics/v2

### DIFF
--- a/dev-resources/puppetlabs/trapperkeeper/services/metrics/metrics_service_test/jolokia-access-permissive.xml
+++ b/dev-resources/puppetlabs/trapperkeeper/services/metrics/metrics_service_test/jolokia-access-permissive.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Jolokia API access policy.
+     Docs: https://jolokia.org/reference/html/security.html -->
+<restrict>
+
+  <!-- Empty test policy. Allows full access. -->
+
+</restrict>

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -21,5 +21,21 @@ metrics: {
             enabled: true
         }
     }
+
+    metrics-webservice: {
+        jolokia: {
+            # Enable or disable the Jolokia-based metrics/v2 endpoint.
+            # Default is true.
+            enabled: false
+
+            # Configure any of the settings listed at:
+            #   https://jolokia.org/reference/html/agents.html#war-agent-installation
+            servlet-init-params: {
+              # Specify a custom security policy:
+              #  https://jolokia.org/reference/html/security.html
+              policyLocation: "file:///etc/puppetlabs/<service name>/jolokia-access.xml"
+            }
+        }
+    }
 }
 ```

--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
                  [org.clojure/tools.logging]
                  [org.slf4j/slf4j-api]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
+                 [org.jolokia/jolokia-core "1.3.5"]
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 

--- a/resources/jolokia-access.xml
+++ b/resources/jolokia-access.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Jolokia API access policy.
+     Docs: https://jolokia.org/reference/html/security.html -->
+<restrict>
+
+  <!-- Only allow read operations on JMX MBeans -->
+  <commands>
+    <command>read</command>
+    <command>list</command>
+    <command>version</command>
+    <command>search</command>
+  </commands>
+
+</restrict>

--- a/src/puppetlabs/trapperkeeper/services/metrics/jolokia.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/jolokia.clj
@@ -1,0 +1,79 @@
+(ns puppetlabs.trapperkeeper.services.metrics.jolokia
+  "Clojure helpers for constructing and configuring Jolokia servlets."
+  (:require [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [schema.core :as schema])
+  (:import [org.jolokia.config ConfigKey]
+           [org.jolokia.util LogHandler]
+           [org.jolokia.http AgentServlet]))
+
+
+(def config-mapping
+  "Inspects the Jolokia ConfigKey Enum and generates a mapping that associates
+  a Clojure keyword with each configuration parameter. The keyword used is the
+  camel-cased identifier that would be used to configure a servlet via a
+  web.xml file. For example, `ConfigKey/AGENT_ID` is associated with the
+  keyword `:agentId`.
+
+  For a complete list of configuration options, see:
+
+    https://jolokia.org/reference/html/agents.html#agent-war-init-params"
+  (->> (ConfigKey/values)
+       (map (juxt
+              #(-> % .getKeyValue keyword)
+              identity))
+       (into {})))
+
+(schema/defschema JolokiaConfig
+  "Schema for validating Clojure maps containing Jolokia configuration.
+
+  Creates a map of optional keys which have string values using the
+  config-mapping extracted from the ConfigKey enum."
+  (->> (keys config-mapping)
+       (map #(vector (schema/optional-key %) schema/Str))
+       (into {})))
+
+(def config-defaults
+  "Default configuration values for Jolokia."
+  {;; Without this, no debug-level messages are produced by the jolokia
+   ;; namespace. Logback configuration still needs to be adjusted to
+   ;; let these messages through.
+   :debug "true"
+   ;; Don't include backtraces in error results returned by the API.
+   :allowErrorDetails "false"
+   ;; Load access policy from: resources/jolokia-access.xml
+   :policyLocation "classpath:/jolokia-access.xml"
+   :mimeType "application/json"})
+
+
+(defn create-servlet-config
+  "Generate Jolokia AgentServlet configuration from a Clojure map"
+  ([]
+   (create-servlet-config {}))
+  ([config]
+   (->> config
+        (merge config-defaults)
+        ;; Validate here to ensure defaults are also valid.
+        (schema/validate JolokiaConfig)
+        walk/stringify-keys)))
+
+(defn create-logger
+  "Return an object that implements the Jolokia logging interface using the
+  logger from clojure.tools.logging"
+  []
+  (reify
+    LogHandler
+    (debug [this message] (log/debug message))
+    (info [this message] (log/info message))
+    (error [this message throwable] (log/error throwable message))))
+
+(defn create-servlet
+  "Builds a Jolokia Servlet that uses Clojure logging."
+  []
+  (proxy [AgentServlet] []
+    ;; NOTE: An alternative to this method override would be to use defrecord
+    ;; to create a class that can be set as `:logHandlerClass` in the servlet
+    ;; configuration. This requires AOT compilation for the namespace defining
+    ;; the record so that Jolokia can find the resulting class.
+    (createLogHandler [_ _]
+      (create-logger))))

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -10,6 +10,8 @@
             [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.trapperkeeper.services.metrics.metrics-utils
              :as metrics-utils]
+            [puppetlabs.trapperkeeper.services.metrics.jolokia
+             :as jolokia]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.i18n.core :as i18n :refer [trs tru]]))
 
@@ -19,13 +21,21 @@
 (def JmxReporterConfig
   {:enabled schema/Bool})
 
+(def JolokiaApiConfig
+  {(schema/optional-key :enabled) schema/Bool
+   (schema/optional-key :servlet-init-params) jolokia/JolokiaConfig})
+
 (def ReportersConfig
   {(schema/optional-key :jmx) JmxReporterConfig})
+
+(def WebserviceConfig
+  {(schema/optional-key :jolokia) JolokiaApiConfig})
 
 (def MetricsConfig
   {:server-id                       schema/Str
    (schema/optional-key :enabled)   schema/Bool
-   (schema/optional-key :reporters) ReportersConfig})
+   (schema/optional-key :reporters) ReportersConfig
+   (schema/optional-key :metrics-webservice) WebserviceConfig})
 
 (def RegistryContext
   {:registry (schema/maybe MetricRegistry)

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -1,4 +1,5 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-service
+  (:import org.jolokia.http.AgentServlet)
   (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services.protocols.metrics :as metrics]
             [puppetlabs.trapperkeeper.services.metrics.metrics-core :as core]
@@ -37,11 +38,14 @@
 
 (trapperkeeper/defservice metrics-webservice
   [[:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler get-route]]
+   [:WebroutingService add-ring-handler get-route]
+   [:WebserverService add-servlet-handler]]
 
   (init [this context]
     (add-ring-handler this
                       (core/build-handler (get-route this)))
+    ; Mounting v2 here so that a new service isn't required.
+    (add-servlet-handler (AgentServlet.) (str (get-route this) "/v2"))
     context)
 
   (stop [this context] context))

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -1,8 +1,8 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-service
-  (:import org.jolokia.http.AgentServlet)
   (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services.protocols.metrics :as metrics]
             [puppetlabs.trapperkeeper.services.metrics.metrics-core :as core]
+            [puppetlabs.trapperkeeper.services.metrics.jolokia :as jolokia]
             [puppetlabs.trapperkeeper.services :as tk-services]))
 
 (trapperkeeper/defservice metrics-service
@@ -38,14 +38,30 @@
 
 (trapperkeeper/defservice metrics-webservice
   [[:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler get-route]
+   [:WebroutingService add-ring-handler get-route get-server]
    [:WebserverService add-servlet-handler]]
 
   (init [this context]
     (add-ring-handler this
                       (core/build-handler (get-route this)))
-    ; Mounting v2 here so that a new service isn't required.
-    (add-servlet-handler (AgentServlet.) (str (get-route this) "/v2"))
+
+    (if (get-in-config [:metrics :metrics-webservice :jolokia :enabled] true)
+      (let [config (->> (get-in-config [:metrics :metrics-webservice :jolokia :servlet-init-params] {})
+                        jolokia/create-servlet-config)
+            ;; NOTE: Normally, these route and server lookups would be done by
+            ;; WebroutingService/add-servlet-handler, but that doesn't properly
+            ;; mount sub-paths at the moment (TK-420). So we explictly compute
+            ;; these items and use WebserverService/add-servlet-handler instead.
+            route (str (get-route this) "/v2")
+            server (get-server this)
+            options (if (nil? server)
+                      {:servlet-init-params config}
+                      {:servlet-init-params config :server-id (keyword server)})]
+        (add-servlet-handler
+          (jolokia/create-servlet)
+          route
+          options)))
+
     context)
 
   (stop [this context] context))


### PR DESCRIPTION
This patch adds the jolokia-core library to the dependency list and
mounts its servlet at 'metrics/v2' when the `metrics-webservice` is in
use. Jolokia is a small library that wraps a REST API around JMX and
provides great features such as globbing, attribute extraction and much
more.

Example query using globbing and parameter extraction:

```
curl -k 'https://localhost:8140/metrics/v2/read/java.lang:name=*,type=GarbageCollector/CollectionCount,CollectionTime'
```

**CAVEATS**
- The Jolokia API also exposes JMX control functionality, so "write"
  and "exec" operations are currently restricted by a static
  authorization configuration in `resources/jolokia-access.xml`.
- The servlet is currently mounted directly using the WebserverService
  add-servlet-handler method, instead of going through the comidi
  routes defined in:
  
  ```
  puppetlabs.trapperkeeper.services.metrics.metrics-core
  ```
