### PR TITLE
(TK-404) (SPIKE) Add jolokia Ring handler as metrics/v2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,6 +42,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-api "1.7.13"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
+                 [org.jolokia/jolokia-core "1.3.5"]
                  [puppetlabs/comidi "0.3.1"]
                  [puppetlabs/i18n "0.4.1"]]
 

--- a/resources/jolokia-access.xml
+++ b/resources/jolokia-access.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Jolokia API access policy.
+     Docs: https://jolokia.org/reference/html/security.html -->
+<restrict>
+
+  <!-- Only allow read operations on JMX MBeans -->
+  <commands>
+    <command>read</command>
+    <command>list</command>
+    <command>version</command>
+    <command>search</command>
+  </commands>
+
+</restrict>

--- a/src/puppetlabs/jolokia.clj
+++ b/src/puppetlabs/jolokia.clj
@@ -91,9 +91,6 @@
 (defn create-backend [config logger restrictor]
   (BackendManager. config logger restrictor))
 
-(defn create-handler []
-  (let [config (create-config)
-        logger (create-logger)
-        restrictor (create-restrictor config logger)
-        backend (create-backend config logger restrictor)]
-    (new HttpRequestHandler config backend logger)))
+(defn create-handler
+  [config backend logger]
+  (HttpRequestHandler. config backend logger))

--- a/src/puppetlabs/jolokia.clj
+++ b/src/puppetlabs/jolokia.clj
@@ -1,0 +1,49 @@
+(ns puppetlabs.jolokia
+  "Clojure interface to the Jolokia library"
+  (:import [org.jolokia.util LogHandler]
+           [org.jolokia.config ConfigKey Configuration]
+           [org.jolokia.restrictor RestrictorFactory]
+           [org.jolokia.backend BackendManager]
+           [org.jolokia.http HttpRequestHandler])
+  (:require [clojure.tools.logging :as log]))
+
+;; Implementation of the Jolokia logging interface that uses the standard
+;; Clojure logger.
+(defn create-logger []
+  (reify
+    LogHandler
+    (debug [this message] (log/debug message))
+    (info [this message] (log/info message))
+    (error [this message throwable] (log/error throwable message))))
+
+(defn create-config []
+  (new Configuration
+       ;; For configuration options, see:
+       ;;
+       ;;   https://github.com/rhuss/jolokia/blob/v1.3.4/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
+       ;;
+       ;; FIXME: AGENT_ID should be a unique string for each instance.
+       (into-array Object [ConfigKey/AGENT_ID "jolokia-agent"
+                           ;; FIXME: AGENT_CONTEXT should be the actual route
+                           ;; that the handler will be mounted at.
+                           ConfigKey/AGENT_CONTEXT "/metrics/v2"
+                           ;; Enables info logged at debug level.
+                           ConfigKey/DEBUG "true"
+                           ;; Don't inclue backtraces in error results returned by the API.
+                           ConfigKey/INCLUDE_STACKTRACE "false"
+                           ;; Load access policy from: resources/jolokia-access.xml
+                           ConfigKey/POLICY_LOCATION "classpath:/jolokia-access.xml"])))
+
+(defn create-restrictor [config logger]
+  ;; Resulting restrictor is configured according to the contents of POLICY_LOCATION
+  (RestrictorFactory/createRestrictor config logger))
+
+(defn create-backend [config logger restrictor]
+  (BackendManager. config logger restrictor))
+
+(defn create-handler []
+  (let [config (create-config)
+        logger (create-logger)
+        restrictor (create-restrictor config logger)
+        backend (create-backend config logger restrictor)]
+    (new HttpRequestHandler config backend logger)))

--- a/src/puppetlabs/jolokia.clj
+++ b/src/puppetlabs/jolokia.clj
@@ -5,7 +5,53 @@
            [org.jolokia.restrictor RestrictorFactory]
            [org.jolokia.backend BackendManager]
            [org.jolokia.http HttpRequestHandler])
-  (:require [clojure.tools.logging :as log]))
+  (:require [clojure.tools.logging :as log]
+            [clojure.set :as setutils]
+            [schema.core :as schema]))
+
+(def config-mapping
+  "Inspects the Jolokia ConfigKey Enum and generates a mapping that associates
+  a Clojure keyword with each entry. For example, `ConfigKey/AGENT_ID` is
+  associated with `:agent-id`
+
+  For a complete list of configuration options, see:
+
+    https://github.com/rhuss/jolokia/blob/v1.3.4/agent/core/src/main/java/org/jolokia/config/ConfigKey.java"
+  (into {}
+        (map
+         #(vector
+           (-> %
+               .name
+               .toLowerCase
+               (.replace "_" "-")
+               keyword)
+           %)
+         (ConfigKey/values))))
+
+(def JolokiaConfig
+  "Schema for validating Clojure maps containing Jolokia configuration.
+
+  Creates a map of optional keys which have string values using the
+  config-mapping extracted from the ConfigKey enum."
+  (into {}
+        (map
+         #(vector (schema/optional-key %) schema/Str)
+         (keys config-mapping))))
+
+(def JolokiaConfigKey
+  "Schema for validating Clojure Keywords that map to Jolokia configuration."
+  (apply schema/enum (keys config-mapping)))
+
+(def config-defaults
+  "Default configuration values for Jolokia agents."
+  ;; NOTE: each agent should be created with a unique :agent-id.
+  {:agent-id "trapperkeeper-metrics"
+   ;; Enables info logged at debug level.
+   :debug "true"
+   ;; Don't inclue backtraces in error results returned by the API.
+   :include-stacktrace "false"
+   ;; Load access policy from: resources/jolokia-access.xml
+   :policy-location "classpath:/jolokia-access.xml"})
 
 ;; Implementation of the Jolokia logging interface that uses the standard
 ;; Clojure logger.
@@ -16,26 +62,30 @@
     (info [this message] (log/info message))
     (error [this message throwable] (log/error throwable message))))
 
-(defn create-config []
-  (new Configuration
-       ;; For configuration options, see:
-       ;;
-       ;;   https://github.com/rhuss/jolokia/blob/v1.3.4/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
-       ;;
-       ;; FIXME: AGENT_ID should be a unique string for each instance.
-       (into-array Object [ConfigKey/AGENT_ID "jolokia-agent"
-                           ;; FIXME: AGENT_CONTEXT should be the actual route
-                           ;; that the handler will be mounted at.
-                           ConfigKey/AGENT_CONTEXT "/metrics/v2"
-                           ;; Enables info logged at debug level.
-                           ConfigKey/DEBUG "true"
-                           ;; Don't inclue backtraces in error results returned by the API.
-                           ConfigKey/INCLUDE_STACKTRACE "false"
-                           ;; Load access policy from: resources/jolokia-access.xml
-                           ConfigKey/POLICY_LOCATION "classpath:/jolokia-access.xml"])))
+(defn create-config
+  "Generate a Jolokia Configuration object from a Clojure map"
+  ([]
+   (create-config {}))
+
+  ([config]
+   (let [configuration (merge config-defaults config)]
+     ;; Validate here to ensure defaults are also conformant.
+     (schema/validate JolokiaConfig configuration)
+     ;; The call to rename-keys uses the config-mapping to translate Clojure
+     ;; keywords into entries in the org.jolokia.config.ConfigKey enum.
+     (Configuration. (->> (setutils/rename-keys configuration config-mapping)
+                          seq
+                          flatten
+                          (into-array Object))))))
+
+(schema/defn ^:always-validate get-config
+  "Looks up a value in a Jolokia Configuration object using a Clojure keyword."
+  [config kwd :- JolokiaConfigKey]
+  (.get config (get config-mapping kwd)))
 
 (defn create-restrictor [config logger]
-  ;; Resulting restrictor is configured according to the contents of POLICY_LOCATION
+  ;; Resulting restrictor is configured according to the contents of
+  ;; :policy-location in the config.
   (RestrictorFactory/createRestrictor config logger))
 
 (defn create-backend [config logger restrictor]

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -8,7 +8,6 @@
             [ring.middleware.defaults :as ring-defaults]
             [ring.util.request :as requtils]
             [puppetlabs.comidi :as comidi]
-            [puppetlabs.jolokia :as jolokia]
             [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.trapperkeeper.services.metrics.metrics-utils
              :as metrics-utils]
@@ -111,11 +110,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Comidi
 
-(defn build-handler [path]
-  ;; NOTE: Is this really the right place to create a persistent
-  ;; handler instance? Does it make more sense to create this as
-  ;; part of the service init?
-  (let [jolokia-handler (jolokia/create-handler)]
+(defn build-handler [path jolokia-handler]
   (comidi/routes->handler
    (comidi/wrap-routes
     (comidi/context path
@@ -166,4 +161,4 @@
                       (ringutils/json-response 200 mbean)
                       (ringutils/json-response 404
                                                (tru "No mbean ''{0}'' found" name)))))))))
-    (comp i18n/locale-negotiator #(ring-defaults/wrap-defaults % ring-defaults/api-defaults))))))
+    (comp i18n/locale-negotiator #(ring-defaults/wrap-defaults % ring-defaults/api-defaults)))))


### PR DESCRIPTION
This is an alternate take on PR #31 , which wraps the Jolokia `HttpRequestHandler` class into a Ring handler instead of mounting the AgentServlet. The AgentServlet does take care of some additional things like CORS support and cache control headers:

https://github.com/rhuss/jolokia/blob/v1.3.4/agent/core/src/main/java/org/jolokia/http/AgentServlet.java#L250-L278

The benefits of this approach is that the resulting API can be wrapped in Ring middleware, such as trapperkeeper-auth, and is better integrated with logging. Jolokia Agent configuration is also easier to control.

The downside is that this is a lot more code to maintain compared to just mounting the Servlet.
