### PR TITLE
(TK-404) (FOR REVIEW ONLY) Add jolokia api as metrics/V2 with tk-auth support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
                  [commons-codec "1.9"]
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.reader "1.0.0-alpha1"]
-                 [prismatic/schema "1.1.0"]
+                 [org.clojure/tools.cli "0.3.4"]
+                 [prismatic/schema "1.1.1"]
                  [slingshot "0.12.2"]
                  [commons-io "2.4"]
                  [ring/ring-servlet "1.4.0"]
@@ -22,6 +23,7 @@
 
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
+                 [puppetlabs/trapperkeeper-authorization "0.7.0"]
                  [puppetlabs/ring-middleware "1.0.0"]
 
                  [ring/ring-core "1.4.0"]
@@ -44,6 +46,7 @@
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
                  [org.jolokia/jolokia-core "1.3.5"]
                  [puppetlabs/comidi "0.3.1"]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1" :exclusions [clj-time]]
                  [puppetlabs/i18n "0.4.1"]]
 
   :plugins [[puppetlabs/i18n "0.4.1"]]
@@ -56,4 +59,7 @@
   :profiles {:dev {:dependencies [[puppetlabs/http-client "0.5.0" :exclusions [commons-io]]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1" :exclusions [clj-time]]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]]}})
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]]}}
+
+  :main puppetlabs.trapperkeeper.main
+  )

--- a/project.clj
+++ b/project.clj
@@ -42,6 +42,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-api "1.7.13"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
+                 [org.jolokia/jolokia-core "1.3.5"]
                  [puppetlabs/comidi "0.3.1"]
                  [puppetlabs/i18n "0.4.1"]]
 

--- a/resources/jolokia-access.xml
+++ b/resources/jolokia-access.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Jolokia API access policy.
+     Docs: https://jolokia.org/reference/html/security.html -->
+<restrict>
+
+  <!-- Only allow read operations on JMX MBeans -->
+  <commands>
+    <command>read</command>
+    <command>list</command>
+    <command>version</command>
+    <command>search</command>
+  </commands>
+
+</restrict>

--- a/src/puppetlabs/trapperkeeper/services/metrics/jolokia.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/jolokia.clj
@@ -1,0 +1,31 @@
+(ns puppetlabs.trapperkeeper.services.metrics.jolokia
+  (:require [ring.util.servlet :as ring-servlet]
+            [clojure.tools.logging :as log])
+  (:import (javax.servlet.http HttpServletRequest)
+           (org.jolokia.http AgentServlet)
+           (org.jolokia.util LogHandler)))
+
+(defn jolokia-agent-servlet
+  "Creates a servlet that will do an authorization check using a ring handler,
+  and then (if the request is authorized) calls into the Jolokia AgentServlet."
+  [auth-check-fn]
+  (let [check-auth (fn [^HttpServletRequest request]
+                     (auth-check-fn
+                      (ring-servlet/build-request-map request)))]
+    (proxy [AgentServlet] []
+      (createLogHandler [_ _]
+        (reify
+          LogHandler
+          (debug [this message]
+            (log/debug message))
+          (info [this message] (log/info message))
+          (error [this message throwable] (log/error throwable message))))
+      (service [request response]
+        (let [{:keys [authorized message]} (check-auth request)]
+          (if-not authorized
+            (ring-servlet/update-servlet-response
+             response
+             {:status 403
+              :headers {}
+              :body message})
+            (proxy-super service request response)))))))

--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -1,4 +1,5 @@
 (ns puppetlabs.trapperkeeper.services.metrics.metrics-service
+  (:import org.jolokia.http.AgentServlet)
   (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services.protocols.metrics :as metrics]
             [puppetlabs.trapperkeeper.services.metrics.metrics-core :as core]
@@ -37,11 +38,14 @@
 
 (trapperkeeper/defservice metrics-webservice
   [[:ConfigService get-in-config]
-   [:WebroutingService add-ring-handler get-route]]
+   [:WebroutingService add-ring-handler get-route]
+   [:WebserverService add-servlet-handler]]
 
   (init [this context]
     (add-ring-handler this
                       (core/build-handler (get-route this)))
+    ; Mounting v2 here so that a new service isn't required.
+    (add-servlet-handler (AgentServlet.) (str (get-route this) "/v2"))
     context)
 
   (stop [this context] context))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -11,7 +11,9 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9-service]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.app :as app]
-            [puppetlabs.kitchensink.core :as ks]))
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-service
+             :as authorization-service]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -27,7 +29,13 @@
    :webserver {:port 8180
                :host "0.0.0.0"}
    :web-router-service {:puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
-                        "/metrics"}})
+                        "/metrics"}
+   :authorization {:version 1
+                   :rules [{:match-request {:path "/"
+                                            :type "path"}
+                            :allow-unauthenticated true
+                            :name "allow all"
+                            :sort-order 500}]}})
 
 (deftest test-metrics-service
   (testing "Can boot metrics service and access registry"
@@ -35,6 +43,7 @@
      app
      [jetty9-service/jetty9-service
       webrouting-service/webrouting-service
+      authorization-service/authorization-service
       metrics-service
       metrics-webservice]
      metrics-service-config
@@ -126,6 +135,7 @@
        app
        [jetty9-service/jetty9-service
         webrouting-service/webrouting-service
+        authorization-service/authorization-service
         metrics-service
         metrics-webservice]
        config


### PR DESCRIPTION
This PR builds on the work from #31, which would register Jolokia's AgentServlet under the "/<metrics>/v2" endpoint.  The primary change this PR adds is the ability to wrap tk-auth middleware around the servlet.  It also demonstrates how the servlet can be further customized, e.g., to add Clojure logging support like is done in #33. 
