### PR TITLE
(TK-394) Accept keyword or string metric domains.

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -14,9 +14,10 @@
         (is (logged? #"^Metrics are now always enabled." :warn))
         (is (instance? MetricRegistry (:registry context))))))
   (testing "initializes registry and adds to context"
-    (let [context (initialize {:server-id "localhost"} "my.epic.domain")]
-      (is (instance? MetricRegistry (:registry context)))
-      (is (nil? (:jmx-reporter context)))))
+    (doseq [domain ["my.epic.domain" :my.epic.domanin]]
+      (let [context (initialize {:server-id "localhost"} domain)]
+        (is (instance? MetricRegistry (:registry context)))
+        (is (nil? (:jmx-reporter context))))))
   (testing "enables jmx reporter if configured to do so"
     (let [context (initialize {:server-id "localhost"
                                :reporters


### PR DESCRIPTION
The PE implementation of this protocol enforces that only keywords be
used for the metric domains, whereas this implementation takes strings.
In the future both implementations will only take keywords, since the
domain is used as a lookup key so a keyword is a better fit. In light of
this, change this implementation to take keywords or strings so it's
easy for consumers to use this implementation or the PE one, and in the
future we can make the breaking change of only accepting keyword
domains.