### PR TITLE
(TK-427) Request stream is closed before parsing finishes

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -96,7 +96,7 @@
                 (fn [req]
                   (try
                     (let [metrics (with-open [reader (-> req :body io/reader)]
-                                    (json/parse-stream reader true))]
+                                    (doall (json/parse-stream reader true)))]
                       (cond
                         (seq? metrics)
                         (ringutils/json-response


### PR DESCRIPTION
Cheshire's parse-stream will return a lazy-seq if the top level JSON
structure is an array. Currently the code calls parse-stream inside a
with-open block and for larger arrays this will cause the lazy-seq to
be realized after the stream has been closed causing an
exception. This commit just wraps that in a doall to ensure the seq is
realized before closing the stream.