### PR TITLE
(TK-430) Bump clj-parent to 0.3.3 and i18n to 0.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -34,7 +34,7 @@
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 
-  :plugins [[puppetlabs/i18n "0.4.3"]
+  :plugins [[puppetlabs/i18n "0.6.0"]
             [lein-parent "0.3.1"]]
 
 


### PR DESCRIPTION
This commit bumps the clj-parent dependency to 0.3.3 and i18n plugin
dependency to 0.6.0.