### PR TITLE
(TK-394) Pass in domain as keyword only

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -26,7 +26,7 @@ metrics: {
     server-id: localhost
 
     registries: {
-        "my-application": {
+        my-application: {
 
             # specify metrics to include in addition to the default list provided.
             # The combination of these two lists will be what gets exported to graphite and

--- a/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -97,9 +97,8 @@
   "Create initial registry context. This will include a MetricsRegistry and a
   JMX reporter, but not a Graphite reporter."
   [config :- (schema/maybe RegistryConfig)
-   domain :- (schema/maybe Keyword-or-Str)]
-  (let [domain (keyword domain)
-        jmx-config (get-in config [:reporters :jmx])
+   domain :- schema/Keyword]
+  (let [jmx-config (get-in config [:reporters :jmx])
         registry (MetricRegistry.)]
     {:registry registry
      :jmx-reporter (when (:enabled jmx-config)

--- a/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -75,9 +75,9 @@
   {:default-metrics-allowed [schema/Str]})
 
 (def MetricsServiceContext
-  {:registries (schema/atom {schema/Any RegistryContext})
+  {:registries (schema/atom {schema/Keyword RegistryContext})
    :can-update-registry-settings? schema/Bool
-   :registry-settings (schema/atom {schema/Any DefaultRegistrySettings})
+   :registry-settings (schema/atom {schema/Keyword DefaultRegistrySettings})
    :metrics-config MetricsConfig})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -32,8 +32,6 @@
 (def WebserviceConfig
   {(schema/optional-key :jolokia) JolokiaApiConfig})
 
-(def Keyword-or-Str (schema/if keyword? schema/Keyword schema/Str))
-
 (def BaseGraphiteReporterConfig
   {:host schema/Str
    :port schema/Int

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -13,7 +13,7 @@
 
 (deftest test-initialize-registry-context
   (testing "initializes registry and adds to context"
-    (let [domain :my.epic.domanin
+    (let [domain :my.epic.domain
           context (core/initialize-registry-context {} domain)]
       (is (instance? MetricRegistry (:registry context)))
       (is (nil? (:jmx-reporter context)))))

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -13,20 +13,22 @@
 
 (deftest test-initialize-registry-context
   (testing "initializes registry and adds to context"
-    (doseq [domain ["my.epic.domain" :my.epic.domanin]]
-      (let [context (core/initialize-registry-context {} domain)]
-        (is (instance? MetricRegistry (:registry context)))
-        (is (nil? (:jmx-reporter context))))))
+    (let [domain :my.epic.domanin
+          context (core/initialize-registry-context {} domain)]
+      (is (instance? MetricRegistry (:registry context)))
+      (is (nil? (:jmx-reporter context)))))
   (testing "enables jmx reporter if configured to do so"
-    (let [context (core/initialize-registry-context
+    (let [domain :foo.bar.baz
+          context (core/initialize-registry-context
                    {:reporters
-                    {:jmx {:enabled true}}} "foo.bar.baz")]
+                    {:jmx {:enabled true}}} domain)]
       (is (instance? MetricRegistry (:registry context)))
       (is (instance? JmxReporter (:jmx-reporter context)))))
   (testing "does not enable jmx reporter if configured to not do so"
-    (let [context (core/initialize-registry-context
+    (let [domain :foo.bar.baz
+          context (core/initialize-registry-context
                    {:reporters
-                    {:jmx {:enabled false}}} "foo.bar.baz")]
+                    {:jmx {:enabled false}}} domain)]
       (is (instance? MetricRegistry (:registry context)))
       (is (nil? (:jmx-reporter context))))))
 


### PR DESCRIPTION
Update tk-metrics to only take domains as keywords

The metrics service originally only accepted domains as strings,
and then eventually it was decided keywords would be better, and
a PR was created to make the registry functions take in either
strings or keywords to maintain backward compatibility until we
decided to make the breaking change.

That moment has arrived, and so this commit removes the last
references to domains as strings.

This PR is part of a larger set of work to move metrics capabilities into OSS puppetserver from PE, see https://tickets.puppetlabs.com/browse/SERVER-1259