### PR TITLE
(maint) Remove bad test

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -86,11 +86,7 @@
                           (metrics-protocol/get-metrics-registry svc :pl.foo.reg))))
 
          (testing "`get-server-id` works"
-           (is (= "localhost" (metrics-protocol/get-server-id svc))))
-
-         (testing "`initialize-registry-settings` throws an error because it is not yet implemented"
-           (is (thrown? RuntimeException
-                        (metrics-protocol/initialize-registry-settings svc "foo" {"foo" "bar"}))))))
+           (is (= "localhost" (metrics-protocol/get-server-id svc))))))
 
      (testing "returns latest status for all services"
        (let [resp (http-client/get "http://localhost:8180/metrics/v1/mbeans")


### PR DESCRIPTION
Previously, the tk-metrics service didn't have the
`initialize-registry-settings` service function implemented, and the service
would throw an exception if you tried to call it. However, it was recently
updated so that the function is implemented, but the test for this behavior
was still present. The test was incorrectly passing because it was now
throwing a schema error. This commit removes the bad test.