### PR TITLE
(TK-436) Add support for appending registry settings

### DIFF
--- a/documentation/metrics_reporting_and_filtering.md
+++ b/documentation/metrics_reporting_and_filtering.md
@@ -28,8 +28,8 @@ list, and 2) the metric names in the `metrics-allowed` section of the config.
 TK application developers who want to have a list of metric names that users
 cannot change (and don't have to worry about and will always be present after
 upgrade) should set these with the `default-metrics-allowed` setting. This is
-done using the [`initialize-registry-settings` service
-function](./api.md#initialize-registry-settings).
+done using the [`update-registry-settings` service
+function](./api.md#update-registry-settings).
 
 The `metrics-allowed` setting in the config allows users to add additional
 metrics (on top of the `default-metrics-allowed`) that they would like to have

--- a/examples/ring_app/README.md
+++ b/examples/ring_app/README.md
@@ -17,9 +17,8 @@ includes the `count-service-report-me` counter but not the `count-service-dont-r
 counter in its list of `:default-metrics-allowed` for the count service registry:
 
 ~~~~clj
-(initialize-registry-settings :count-service
-                                  {:default-metrics-allowed
-                                   ["count-service-report-me"]})
+(update-registry-settings :count-service
+                          {:default-metrics-allowed ["count-service-report-me"]})
 ~~~~
 
 Metric info for the `count-service-report-me`

--- a/examples/ring_app/src/examples/ring_app/ring_app.clj
+++ b/examples/ring_app/src/examples/ring_app/ring_app.clj
@@ -5,7 +5,7 @@
               [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defservice count-service
-  [[:MetricsService initialize-registry-settings get-metrics-registry get-server-id]
+  [[:MetricsService update-registry-settings get-metrics-registry get-server-id]
    [:WebserverService add-ring-handler]]
   (init [this context]
     (log/info "Count service starting up")
@@ -26,8 +26,8 @@
           :body (str "Requests made since startup: "
                      (.getCount counter-to-report))})
        "/count"))
-    (initialize-registry-settings :count-service
-                                  {:default-metrics-allowed
-                                   ["count-service-report-me"]})
+    (update-registry-settings :count-service
+                              {:default-metrics-allowed
+                               ["count-service-report-me"]})
 
     context))

--- a/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_core.clj
@@ -180,7 +180,7 @@
 
 (schema/defn get-metrics-allowed :- #{schema/Str}
   "Get the metrics allowed for the registry. Looks at the metrics-allowed registered for the
-  registry in the registry settings atom using the `initialize-registry-settings` function as well
+  registry in the registry settings atom using the `update-registry-settings` function as well
   as the metrics-allowed listed in the config file under the `:metrics-allowed` key. Merges these
   lists together and then adds the metrics prefix to them, returning a set of prefixed allowed
   metrics."
@@ -267,7 +267,7 @@
   [context :- MetricsServiceContext]
   (assoc context :can-update-registry-settings? false))
 
-(schema/defn ^:always-validate initialize-registry-settings :- {schema/Any DefaultRegistrySettings}
+(schema/defn ^:always-validate update-registry-settings :- {schema/Any DefaultRegistrySettings}
   "Update the `registry-settings` atom for the given domain. If called again for the same domain,
   the new settings will be merged in, and lists such as :default-metrics-allowed, will be concat'd
   together."

--- a/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/metrics/metrics_service.clj
@@ -35,10 +35,10 @@
   (stop [this context]
     (core/stop-all (tk-services/service-context this)))
 
-  (initialize-registry-settings
+  (update-registry-settings
    [this domain settings]
    (let [context (tk-services/service-context this)]
-     (core/initialize-registry-settings context domain settings)))
+     (core/update-registry-settings context domain settings)))
 
   (get-metrics-registry
    [this]

--- a/src/clj/puppetlabs/trapperkeeper/services/protocols/metrics.clj
+++ b/src/clj/puppetlabs/trapperkeeper/services/protocols/metrics.clj
@@ -15,7 +15,7 @@
    [this]
    "Get the server-id from the `metrics` -> `server-id` part of the config.")
 
-  (initialize-registry-settings
+  (update-registry-settings
    [this domain settings]
    "Allows for specifying settings for a metric registry reporter that don't
    go into a config file. Must be called during the 'init' phase of a

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -143,11 +143,11 @@
           context (core/create-initial-service-context config)
           get-graphite-reporter (fn [domain]
                                   (get-in @(:registries context) [domain :graphite-reporter]))]
-      (core/initialize-registry-settings
+      (core/update-registry-settings
        context :enabled.graphite.with-defaults {:default-metrics-allowed ["bar"]})
-      (core/initialize-registry-settings
+      (core/update-registry-settings
        context :disabled.graphite.with-defaults {:default-metrics-allowed ["bar"]})
-      (core/initialize-registry-settings
+      (core/update-registry-settings
        context :not-in-config.with-defaults {:default-metrics-allowed ["bar"]})
       (core/get-or-initialize-registry-context context :not-in-config)
       (core/add-graphite-reporters context)
@@ -206,20 +206,20 @@
         (is (instance? JmxReporter (get-in registries [:default :jmx-reporter])))
         (is (nil? (get-in registries [:foo :jmx-reporter])))))))
 
-(deftest initialize-registry-settings-test
+(deftest update-registry-settings-test
   (let [context (core/create-initial-service-context utils/test-config)]
-    (testing "initialize-registry-settings adds settings for a registry"
+    (testing "update-registry-settings adds settings for a registry"
       (is (= {:foo.bar {:default-metrics-allowed ["foo.bar"]}}
-             (core/initialize-registry-settings context
-                                                :foo.bar
-                                                {:default-metrics-allowed ["foo.bar"]}))))
-    (testing "initialize-registry-settings appends settings if the settings already exist"
+             (core/update-registry-settings context
+                                            :foo.bar
+                                            {:default-metrics-allowed ["foo.bar"]}))))
+    (testing "update-registry-settings appends settings if the settings already exist"
       (is (= {:foo.bar {:default-metrics-allowed ["foo.bar" "bar.baz"]}}
-             (core/initialize-registry-settings context
-                                                :foo.bar
-                                                {:default-metrics-allowed ["bar.baz"]}))))
-    (testing "initialize-registry-settings throws an error if it is called after init lifecycle phase"
-      (is (thrown? RuntimeException (core/initialize-registry-settings
+             (core/update-registry-settings context
+                                            :foo.bar
+                                            {:default-metrics-allowed ["bar.baz"]}))))
+    (testing "update-registry-settings throws an error if it is called after init lifecycle phase"
+      (is (thrown? RuntimeException (core/update-registry-settings
                                      (core/lock-registry-settings context)
                                      :nope {:default-metrics-allowed ["default"]}))))
 

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_core_test.clj
@@ -213,18 +213,16 @@
              (core/initialize-registry-settings context
                                                 :foo.bar
                                                 {:default-metrics-allowed ["foo.bar"]}))))
+    (testing "initialize-registry-settings appends settings if the settings already exist"
+      (is (= {:foo.bar {:default-metrics-allowed ["foo.bar" "bar.baz"]}}
+             (core/initialize-registry-settings context
+                                                :foo.bar
+                                                {:default-metrics-allowed ["bar.baz"]}))))
     (testing "initialize-registry-settings throws an error if it is called after init lifecycle phase"
       (is (thrown? RuntimeException (core/initialize-registry-settings
                                      (core/lock-registry-settings context)
                                      :nope {:default-metrics-allowed ["default"]}))))
-    (testing "initialize-registry-settings throws an error for a registry that already has settings"
-      (core/initialize-registry-settings context
-                                         :error.registry
-                                         {:default-metrics-allowed ["foo.bar"]})
-      (is (thrown? RuntimeException (core/initialize-registry-settings
-                                     context
-                                     :error.registry
-                                     {:default-metrics-allowed ["another"]}))))
+
     ; Make sure all the graphite reporters get shutdown, otherwise they spawn background threads
     (core/stop-all context)))
 

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -295,23 +295,6 @@
         (finally
           (app/stop metrics-app)))))
 
-  (testing "initialize-registry-settings throws an error for a registry that already has settings"
-    (let [service (trapperkeeper/service
-                   [[:MetricsService initialize-registry-settings]]
-                   (init [this context]
-                         (initialize-registry-settings
-                          :error.registry {:default-metrics-allowed ["foo.bar"]})
-                         (initialize-registry-settings
-                          :error.registry {:default-metrics-allowed ["another"]})
-                         context))
-          metrics-app (trapperkeeper/build-app [service metrics-service]
-                                               {:metrics utils/test-config})]
-      (with-test-logging
-       (try
-         (is (thrown? RuntimeException (app/check-for-errors! (app/init metrics-app))))
-         (finally
-           (app/stop metrics-app))))))
-
   (testing "initialize-registry-settings throws an error if called outside `init`"
     (let [service (trapperkeeper/service
                    [[:MetricsService initialize-registry-settings]]

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -277,12 +277,12 @@
      (testing "Can access server-id"
        (is (= "foo" (metrics-protocol/get-server-id svc)))))))
 
-(deftest initialize-registry-settings-service-function-test
+(deftest update-registry-settings-service-function-test
   (testing "intialize-registry-settings adds settings for a registry"
     (let [service (trapperkeeper/service
-                   [[:MetricsService initialize-registry-settings]]
+                   [[:MetricsService update-registry-settings]]
                    (init [this context]
-                         (initialize-registry-settings :foo.bar {:default-metrics-allowed ["foo.bar"]})
+                         (update-registry-settings :foo.bar {:default-metrics-allowed ["foo.bar"]})
                          context))
           metrics-app (trapperkeeper/build-app [service metrics-service]
                                                {:metrics utils/test-config})
@@ -295,11 +295,11 @@
         (finally
           (app/stop metrics-app)))))
 
-  (testing "initialize-registry-settings throws an error if called outside `init`"
+  (testing "update-registry-settings throws an error if called outside `init`"
     (let [service (trapperkeeper/service
-                   [[:MetricsService initialize-registry-settings]]
+                   [[:MetricsService update-registry-settings]]
                    (start [this context]
-                          (initialize-registry-settings :nope {:default-metrics-allowed ["fail"]})
+                          (update-registry-settings :nope {:default-metrics-allowed ["fail"]})
                           context))
           metrics-app (trapperkeeper/build-app [service metrics-service]
                                                {:metrics utils/test-config})]
@@ -371,20 +371,20 @@
          :graphite-with-defaults-and-metrics-allowed (merge metrics-allowed graphite-enabled)}
         config {:metrics (utils/build-config-with-registries registries-config)}
         service (trapperkeeper/service
-                 [[:MetricsService get-metrics-registry initialize-registry-settings]]
+                 [[:MetricsService get-metrics-registry update-registry-settings]]
                  (init
                   [this context]
                   (get-metrics-registry :graphite-enabled)
 
                   (get-metrics-registry :graphite-with-default-metrics-allowed)
-                  (initialize-registry-settings :graphite-with-default-metrics-allowed
+                  (update-registry-settings :graphite-with-default-metrics-allowed
                                                 default-metrics-allowed)
 
                   (get-metrics-registry :graphite-with-metrics-allowed)
 
                   ;; shouldn't matter whether `get-metrics-registry` or
-                  ;; `initialize-registry-settings` is called first
-                  (initialize-registry-settings :graphite-with-defaults-and-metrics-allowed
+                  ;; `update-registry-settings` is called first
+                  (update-registry-settings :graphite-with-defaults-and-metrics-allowed
                                                 default-metrics-allowed)
                   (get-metrics-registry :graphite-with-defaults-and-metrics-allowed)
 


### PR DESCRIPTION
This commits changes the behavior of initialize-registry-settings to allow it
to be called more than once for one domain, allowing multiple services to add
in the metrics they would like to whitelist for their domain.

As before, the first call will create the settings. Additional calls with the
same domain will merge and append the new settings to the old settings.

Since the only registry setting is currently :default-metrics-allowed, this
allows multiple TK services to call this service function, adding in their own
list of allowed metrics. Before, only one call could be made per domain, which
meant that you would have to designate a service to be the one that knows about
the list of metrics and initialize them.