### PR TITLE
(maint) Update Jolokia dependency to 1.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.clojure/tools.logging]
                  [io.dropwizard.metrics/metrics-core]
                  [io.dropwizard.metrics/metrics-graphite]
-                 [org.jolokia/jolokia-core "1.3.6"]
+                 [org.jolokia/jolokia-core "1.5.0"]
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 


### PR DESCRIPTION
The commit updates the dependency on jolokia-core to 1.5.0 which is the current
stable version. 1.5.0 includes two security fixes that do not affect
trapperkeeper-metrics usage:

  - An XSS vulnerability that only affects browsers and is already mitigated by
    the jolokia javascript library used by most dasboards that consume data
    from Jolokia. Trapperkeeper does not bundle any of these dashboards.

  - A vulnerability that allowed unrestricted proxying of JMX requests via
    JSR160. Requires a dependency on the jolokia-jsr160 artifact, which
    trapperkeeper-metrics does not have, along with dispatcherClasses to
    be configured to include `org.jolokia.jsr160.Jsr160RequestDispatcher`.