### PR TITLE
(maint) Update Jolokia dependency to 1.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.clojure/tools.logging]
                  [io.dropwizard.metrics/metrics-core]
                  [io.dropwizard.metrics/metrics-graphite]
-                 [org.jolokia/jolokia-core "1.5.0"]
+                 [org.jolokia/jolokia-core "1.6.0"]
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 


### PR DESCRIPTION
The commit updates the dependency on jolokia-core to 1.6.0 which is
the current stable version. 1.6.0 improved the security posture of
the WAR agent. Trapperkeeper metrics uses the JAR agent, so this
update is mostly a noop, but it is good to stay current.