### PR TITLE
Various and sundry updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
 lein: 2.7.1
-jdk:
-- oraclejdk8
+matrix:
+  include:
+    - jdk: openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,3 @@ jdk:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
-  hipchat:
-    rooms:
-      secure: CfGS3yYsocLruSP0lRr9HFwzdZ1HFw4rFEVdJkP/i0i8aIPY3XB3vTQNxw/lIBVRDwWHaUfA+xnyK3itCxt0M0UtPDp1BkU6abLr8Apjet/nJJ2icBvQfnpx1hb6xBpoE69vpRiIVewoU69UPFjXdZd2D1BWX58tNbdV9CA8Ezw=
-    template:
-    - ! '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}'
-    - ! 'Change view: %{compare_url}'
-    - ! 'Build details: %{build_url}'

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.clojure/tools.logging]
                  [io.dropwizard.metrics/metrics-core]
                  [io.dropwizard.metrics/metrics-graphite]
-                 [org.jolokia/jolokia-core "1.6.0"]
+                 [org.jolokia/jolokia-core "1.6.1"]
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.26"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This changeset has several small maintenance commits:

  - Update the Travis CI configuration. Drop OracleJDK 8 as the test platform in favor of OpenJDK 8.
  - Update clj-parent dependency to 1.7.26
  - Update jolokia dependency to 1.6.1