### PR TITLE
(PE-28647) Remove localhost-only access restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+* [PE-28647](https://tickets.puppetlabs.com/browse/PE-28647) - Allow
+  remote connections to the v2 metrics endpoint now that the connection
+  can be authenticated.
+
 ## 1.3.0
 
 * [TK-489](https://tickets.puppetlabs.com/browse/TK-489) - Add

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/trapperkeeper-metrics "1.3.2-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-metrics "1.4.0-SNAPSHOT"
   :description "Trapperkeeper Metrics Service"
   :url "http://github.com/puppetlabs/trapperkeeper-metrics"
 

--- a/resources/jolokia-access.xml
+++ b/resources/jolokia-access.xml
@@ -3,13 +3,6 @@
      Docs: https://jolokia.org/reference/html/security.html -->
 <restrict>
 
-  <!-- Due to CVE-2020-7943, restrict access to localhost -->
-  <remote>
-    <host>localhost</host>
-    <host>127.0.0.1</host>
-    <host>0:0:0:0:0:0:0:1</host>
-  </remote>
-
   <!-- Only allow read operations on JMX MBeans -->
   <commands>
     <command>read</command>


### PR DESCRIPTION
Now that the metrics endpoints can be accessed via an authenticated
connection, we can expose them outside of localhost.