### PR TITLE
(PE-31012) Update to latest clj-parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: clojure
-lein: 2.7.1
+lein: 2.9.1
 matrix:
   include:
     - jdk: openjdk8
-script: ./ext/travisci/test.sh
+script: "lein test"
 notifications:
   email: false

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-lein test

--- a/project.clj
+++ b/project.clj
@@ -2,11 +2,11 @@
   :description "Trapperkeeper Metrics Service"
   :url "http://github.com/puppetlabs/trapperkeeper-metrics"
 
-  :min-lein-version "2.7.1"
+  :min-lein-version "2.9.1"
 
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.26"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -28,10 +28,11 @@
                  [io.dropwizard.metrics/metrics-graphite]
                  [org.jolokia/jolokia-core "1.6.2"]
                  [puppetlabs/comidi]
+                 [org.bouncycastle/bcpkix-jdk15on]
                  [puppetlabs/i18n]]
 
   :plugins [[puppetlabs/i18n "0.6.0"]
-            [lein-parent "0.3.1"]]
+            [lein-parent "0.3.7"]]
 
   :source-paths  ["src/clj"]
   :java-source-paths  ["src/java"]

--- a/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/metrics/metrics_service_test.clj
@@ -122,12 +122,12 @@
                  :let [resp (http-client/get (str "http://localhost:8180/metrics/v1" path))]]
            (is (= 200 (:status resp)))))
 
-       (let [resp (http-client/get "http://localhost:8180/metrics/v2/list")
+       (let [resp (http-client/get "http://localhost:8180/metrics/v2/list/java.lang")
              body (parse-response resp)]
          (is (= 200 (:status  resp)))
-         (doseq [[namesp mbeans] (get body "value") mbean (keys mbeans)
+         (doseq [mbean (keys (get body "value"))
                  :let [url (str "http://localhost:8180/metrics/v2/read/"
-                                (jolokia-encode (str namesp ":" mbean))
+                                (jolokia-encode (str "java.lang:" mbean))
                                 ;; NOTE: Some memory pools intentionally don't
                                 ;; implement MBean attributes. This results
                                 ;; in an error being thrown when those


### PR DESCRIPTION
This picks up an update to ring-parent which mitigates a known
vulnerability in commons-fileupload.