### PR TITLE
(PE-36390) replace use of ring-defaults

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.2.6"]
+  :parent-project {:coords [puppetlabs/clj-parent "6.0.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
Prior to this commit, tk-metrics was using ring-defaults/api-defaults wrappers. This commit replaces that with direct calls to the ring.middleware wrappers needed for the API endpoints.

Also updates clj-parent to v6.0.1