### PR TITLE
(PE-36484) Bump tk-jetty to address Jetty ring handler broken function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* update tk-jetty-10 to 1.0.8 to address broken ring handler getRequestCharacterEncoding() function and set default character encoding of ring handler responses to UTF-8.
+
 ## 2.0.0
 * major breaking change to Jetty 10 using the trapperkeeper-webserver-jetty10 service.
 

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
 
   :profiles {:defaults {:dependencies [[puppetlabs/http-client]
                                        [puppetlabs/trapperkeeper :classifier "test"]
-                                       [com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.1" :exclusions [org.ow2.asm/asm]]
+                                       [com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.8"]
                                        [puppetlabs/kitchensink :classifier "test"]]
                         :resource-paths ["dev-resources"]}
 


### PR DESCRIPTION
Ran 33 tests containing 280 assertions.
0 failures, 0 errors.
