### PR TITLE
(PE-37632) update clj-parent to manage tk-ws-jetty10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 2.0.1
+* update clj-parent to 7.3.6 to allow the version of tk-jetty-10 to be managed
+* update the version of i18n to 0.9.2
+* update the version of lein-parent to 0.3.9
+* update the dependencies to avoid mixing maps and keys in vectors as this is deprecated by lein
+
+## 2.0.1
 * update tk-jetty-10 to 1.0.8 to address broken ring handler getRequestCharacterEncoding() function and set default character encoding of ring handler responses to UTF-8.
 
 ## 2.0.0

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "7.0.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.3.6"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -28,8 +28,8 @@
                  [puppetlabs/comidi]
                  [puppetlabs/i18n]]
 
-  :plugins [[puppetlabs/i18n "0.6.0"]
-            [lein-parent "0.3.7"]]
+  :plugins [[puppetlabs/i18n "0.9.2"]
+            [lein-parent "0.3.9"]]
 
   :source-paths  ["src/clj"]
   :java-source-paths  ["src/java"]
@@ -43,29 +43,28 @@
 
   :profiles {:defaults {:dependencies [[puppetlabs/http-client]
                                        [puppetlabs/trapperkeeper :classifier "test"]
-                                       [com.puppetlabs/trapperkeeper-webserver-jetty10 "1.0.8"]
+                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                        [puppetlabs/kitchensink :classifier "test"]]
                         :resource-paths ["dev-resources"]}
+             :dev-dependencies {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
+             :dev [:defaults :dev-dependencies]
+             :fips-dependencies {:dependencies [[org.bouncycastle/bcpkix-fips]
+                                                [org.bouncycastle/bc-fips]
+                                                [org.bouncycastle/bctls-fips]]
+                                 :jvm-opts ~(let [version (System/getProperty "java.specification.version")
+                                                  [major minor _] (clojure.string/split version #"\.")
+                                                  unsupported-ex (ex-info "Unsupported major Java version. Expects 8, 11 or 17."
+                                                                               {:major major
+                                                                                :minor minor})]
+                                                 (condp = (java.lang.Integer/parseInt major)
+                                                   1 (if (= 8 (java.lang.Integer/parseInt minor))
+                                                       ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]
+                                                       (throw unsupported-ex))
+                                                   11 ["-Djava.security.properties==./dev-resources/java.security.jdk11-fips"]
+                                                   17 ["-Djava.security.properties==./dev-resources/java.security.jdk17-fips"]
+                                                   (throw unsupported-ex)))}
+             :fips [:defaults :fips-dependencies]
 
-             :dev [:defaults
-                   {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
-
-             :fips [:defaults
-                    {:dependencies [[org.bouncycastle/bcpkix-fips]
-                                    [org.bouncycastle/bc-fips]
-                                    [org.bouncycastle/bctls-fips]]
-                     :jvm-opts ~(let [version (System/getProperty "java.specification.version")
-                                      [major minor _] (clojure.string/split version #"\.")
-                                      unsupported-ex (ex-info "Unsupported major Java version. Expects 8, 11 or 17."
-                                                        {:major major
-                                                         :minor minor})]
-                                   (condp = (java.lang.Integer/parseInt major)
-                                     1 (if (= 8 (java.lang.Integer/parseInt minor))
-                                         ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]
-                                         (throw unsupported-ex))
-                                     11 ["-Djava.security.properties==./dev-resources/java.security.jdk11-fips"]
-                                     17 ["-Djava.security.properties==./dev-resources/java.security.jdk17-fips"]
-                                     (throw unsupported-ex)))}]
 
              ;; per https://github.com/technomancy/leiningen/issues/1907
              ;; the provided profile is necessary for lein jar / lein install


### PR DESCRIPTION
In order to move to centralized management of trapperkeeper-webserver-jetty-10, this
moves to clj-parent 7.3.6, and removes the version pin from tk-ws-jetty-10

Other outdated dependencies were also updated.

Additionally, profile declarations that mixed keys of other profiles and
maps were refactored to just include keys as the previous format is now
deprecated and not recommended.

It also prepares for a release.