### PR TITLE
(maint) add license key, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.0.1
+## 2.0.3
+* add the license key to project.clj to allow promotion to clojars 
+
+## 2.0.2 -- not released to clojars due to license key misssing
 * update clj-parent to 7.3.6 to allow the version of tk-jetty-10 to be managed
 * update the version of i18n to 0.9.2
 * update the version of lein-parent to 0.3.9

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject puppetlabs/trapperkeeper-metrics "2.0.3-SNAPSHOT"
   :description "Trapperkeeper Metrics Service"
   :url "http://github.com/puppetlabs/trapperkeeper-metrics"
+  :license {:name "Apache License, Version 2.0"
+              :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
   :min-lein-version "2.9.1"
 


### PR DESCRIPTION
This adds the license key to the project.clj to allow the project to be published to clojars.

It also updates the changelog